### PR TITLE
v2015.10.06.1

### DIFF
--- a/Darbeliai.versija
+++ b/Darbeliai.versija
@@ -1,8 +1,9 @@
-Darbeliai v2015.10.05.4
+Darbeliai v2015.10.06.1
 
-Patobulinimai peržiūrint ICA per nuoseklaus apdorojimo langą.
-Nenulūžti rodant būsenos langelį, kai naudojama MATLAB R2015b.
+Nuosekliame apdorojime ir SĮSP savybių lange 
+išjungti filtrą rinkmenų, atrinkimui vos tik jos
+pradedamos žymėti rankiniu būdu.
 
-Enhanced ICA reviewing via Serial processing dialog.
-Don't crash at dialog of statusbar in MATLAB R2015b.
-
+In Serial processing and ERP properties dialog:
+turn off filtering files by key as soon as 
+user selects files manually.

--- a/UTF-8/darbeliu_istorija.m
+++ b/UTF-8/darbeliu_istorija.m
@@ -1,6 +1,11 @@
 %
 % Pakeitimai:
 % ------------------------
+% v2015.10.06.1
+% ~ Nuosekliame apdorojime ir SĮSP savybių lange 
+%   išjungti filtrą rinkmenų, atrinkimui vos tik jos
+%   pradedamos žymėti rankiniu būdu.
+%
 % v2015.10.05.1
 % ~ Patobulinimai peržiūrint ICA per nuoseklaus apdorojimo langą.
 % ~ Nenulūžti rodant būsenos langelį, kai naudojama MATLAB R2015b.

--- a/UTF-8/pop_Epochavimas_ir_atrinkimas.m
+++ b/UTF-8/pop_Epochavimas_ir_atrinkimas.m
@@ -987,6 +987,11 @@ function listbox1_Callback(hObject, eventdata, handles)
 
 % Hints: contents = cellstr(get(hObject,'String')) returns listbox1 contents as cell array
 %        contents{get(hObject,'Value')} returns selected item from listbox1
+if ~strcmp(get(handles.edit_failu_filtras2,'Style'),'pushbutton') ;
+    set(handles.edit_failu_filtras2,'Style','pushbutton');
+    set(handles.edit_failu_filtras2,'String',lokaliz('Filter'));
+    set(handles.edit_failu_filtras2,'BackgroundColor','remove');
+end;
 Ar_galima_vykdyti(hObject, eventdata, handles)
 
 % --- Executes during object creation, after setting all properties.

--- a/UTF-8/pop_nuoseklus_apdorojimas.m
+++ b/UTF-8/pop_nuoseklus_apdorojimas.m
@@ -2695,6 +2695,11 @@ function listbox1_Callback(hObject, eventdata, handles)
 
 % Hints: contents = cellstr(get(hObject,'String')) returns listbox1 contents as cell array
 %        contents{get(hObject,'Value')} returns selected item from listbox1
+if ~strcmp(get(handles.edit_failu_filtras2,'Style'),'pushbutton') ;
+    set(handles.edit_failu_filtras2,'Style','pushbutton');
+    set(handles.edit_failu_filtras2,'String',lokaliz('Filter'));
+    set(handles.edit_failu_filtras2,'BackgroundColor','remove');
+end;
 Ar_galima_vykdyti(hObject, eventdata, handles)
 
 % --- Executes during object creation, after setting all properties.


### PR DESCRIPTION
Darbeliai v2015.10.06.1

Nuosekliame apdorojime ir SĮSP savybių lange 
išjungti filtrą rinkmenų, atrinkimui vos tik jos
pradedamos žymėti rankiniu būdu.

In Serial processing and ERP properties dialog:
turn off filtering files by key as soon as 
user selects files manually.
