### PR TITLE
v2015.11.24.1

### DIFF
--- a/Darbeliai.versija
+++ b/Darbeliai.versija
@@ -1,7 +1,13 @@
-Darbeliai v2015.11.21.1
+Darbeliai v2015.11.24.1
 
-Interpoliavus kanalus, pasirinktinai atmesti arba palikti 
-nepasirinktuosius kanalus. Anksčiau jie atmetinėti.
+„Nuoseklaus apdorojimo“ lange,
+NKA komponenčių peržiūroje, kai pasirinkta 
+parinktis „Laukti patvirtinimo (Darbeliai)“
+(beje, numatytoji yra „Laukti patvirtinimo (EEGLAB)“),
+suteikti mygtukams „Ne“ ir „Priimti“ tinkamas funkcijas.
 
-You can choose to leave or reject not-selected channels
-after interpolation. Earler versions rejected not-selected channels.
+In "Serial processing" ICA review/reject job:
+if option "Wait for confirmation (Darbeliai)" is 
+selected (though "Wait for cnofirmation (EEGLAB)"
+is default), assign correct actions to buttons 
+"No" and "Accecpt".

--- a/UTF-8/darbeliu_istorija.m
+++ b/UTF-8/darbeliu_istorija.m
@@ -1,6 +1,13 @@
 %
 % Pakeitimai:
 % ------------------------
+% v2015.11.24.1
+% ~ „Nuoseklaus apdorojimo“ lange,
+%   NKA komponenčių peržiūroje, kai pasirinkta 
+%   parinktis „Laukti patvirtinimo (Darbeliai)“
+%   (beje, numatytoji yra „Laukti patvirtinimo (EEGLAB)“),
+%   suteikti mygtukams „Ne“ ir „Priimti“ tinkamas funkcijas.
+%
 % v2015.11.21.1
 % + Interpoliavus kanalus, pasirinktinai atmesti arba palikti 
 %   nepasirinktuosius kanalus. Anksčiau jie atmetinėti.

--- a/UTF-8/pop_nuoseklus_apdorojimas.m
+++ b/UTF-8/pop_nuoseklus_apdorojimas.m
@@ -1748,9 +1748,9 @@ for i=1:Pasirinktu_failu_N;
                                 
                                 ats=getappdata(0, 'mygtuko_pasirinkimas');
                                 switch ats
-                                    case { 0 lokaliz('Priimti') lokaliz('Yes') }
+                                    case { 1 lokaliz('Priimti') lokaliz('Yes') }
                                         EEG = EEG_naujas;
-                                    case { 1 lokaliz('Atmesti') lokaliz('No') }
+                                    case { 0 lokaliz('Atmesti') lokaliz('No') }
                                         EEG = EEG_senas;
                                     otherwise
                                         uzverti_EEG_perziuru_langus([ '.*' NaujaRinkmena_be_galunes '.*' ]);


### PR DESCRIPTION
„Nuoseklaus apdorojimo“ lange, NKA komponenčių peržiūroje, kai pasirinkta parinktis „Laukti patvirtinimo (Darbeliai)“ (beje, numatytoji yra „Laukti patvirtinimo (EEGLAB)“), suteikti mygtukams „Ne“ ir „Priimti“ tinkamas funkcijas.